### PR TITLE
ECE 562 Marimo Notebook: rewrite HW02 gdsfactory cell and hide boilerplate code by default

### DIFF
--- a/marimo_course/assignments/hw02_mzi_modelling.py
+++ b/marimo_course/assignments/hw02_mzi_modelling.py
@@ -13,13 +13,13 @@ __generated_with = "0.18.4"
 app = marimo.App()
 
 
-@app.cell
+@app.cell(hide_code=True)
 def _():
     import marimo as mo
     return (mo,)
 
 
-@app.cell
+@app.cell(hide_code=True)
 def _(mo):
     mo.md(r"""
     # HW02 — MZI modelling (FSR and ΔL)
@@ -57,7 +57,7 @@ def fsr_estimate_nm(*, wl0_nm: float, ng: float, delta_L_um: float) -> float | N
     return None
 
 
-@app.cell
+@app.cell(hide_code=True)
 def _(mo):
     mo.md(r"""
     ## Task 1 — Implement `fsr_estimate_nm`
@@ -71,7 +71,7 @@ def _(mo):
     return
 
 
-@app.cell
+@app.cell(hide_code=True)
 def _(mo):
     wl0_nm_check = 1550.0
     ng_check = 4.19
@@ -89,7 +89,7 @@ def _(mo):
     return
 
 
-@app.cell
+@app.cell(hide_code=True)
 def _(mo):
     mo.md(r"""
     ## Task 2 — Choose ΔL (a design decision)
@@ -98,7 +98,7 @@ def _(mo):
 
     For this homework, assume:
     - center wavelength: **1550 nm**
-    - measurement span: **60 nm** (adjust to match what you used in the lab notebook if different)
+    - measurement span: **100 nm** (adjust to match what you used in the lab notebook if different)
     - desired fringes visible across the span: **≥ 3**
 
     Edit the variables in the next cell to record your choice and justification.

--- a/marimo_course/assignments/hw02_mzi_modelling.py
+++ b/marimo_course/assignments/hw02_mzi_modelling.py
@@ -111,7 +111,7 @@ def _(mo):
     # === EDIT THIS CELL ===
     wl0_nm = 1550.0
     ng = 4.19
-    measurement_span_nm = 60.0
+    measurement_span_nm = 100.0
 
     chosen_delta_L_um = 25.0
     justification = "Replace this with a short paragraph."


### PR DESCRIPTION
@rmcamacho I've implemented some Marimo notebook improvements for ECE 562:

- I simplified the gdsfactory cell in HW02 significantly (where we lay out MZI and grating couplers). I think this will help eliminate confusion surrounding the gdsfactory API. There seemed to be a lot of fluff code (probably from ChatGPT/Claude?).
- Code cells that don't need to be edited by the student (code that imports marimo, produces the headers/markdown, etc.) are now hidden by default. This de-clutters the notebook significantly.

These changes (particularly the first one) could cause a merge conflict with some students' code. I think it would still be worth it to push this out because of how much it simplifies things.